### PR TITLE
0-0-1-welcome-to-java-web-exercises: update spring-boot-dependencies version from 2.4.0 to 2.5.0

### DIFF
--- a/0-0-intro/0-0-1-welcome-to-java-web-exercises/pom.xml
+++ b/0-0-intro/0-0-1-welcome-to-java-web-exercises/pom.xml
@@ -48,7 +48,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.4.0</version>
+                <version>2.5.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Update spring-boot-dependencies version from 2.4.0 to 2.5.0
 Spring Boot 2.4.0 works just only with JDK 15 or less. And when you run the application with JDK 17 it throws an error. An update to version 2.5.0 resolves that issue.
![image](https://github.com/bobocode-projects/java-web-exercises/assets/60611618/bb993bea-331c-4c5c-b501-c99a9bea8ab9)
